### PR TITLE
PKA File Format Draft

### DIFF
--- a/docs/PKA-File-Structure.md
+++ b/docs/PKA-File-Structure.md
@@ -1,0 +1,72 @@
+# Table of Contents
+- [Package Archive Files (PKA Layout)](#package-archive-files-pka-layout)
+  - [Structures](#structures)
+    - [Header Structure](#header-structure)
+    - [File Entry Structure](#file-entry-structure)
+    - [Compression Entry Structure](#compression-entry-structure)
+
+## Package Archive Files (PKA Layout)
+
+The PKA/Package archive file consists of a `signature` a repeating array of `package headers` along with its corresponding `file entries`; an array of `compression entries` and the raw data for the file entries themselves (compressed or uncompressed).
+
+The PC game files that the following records document are Little Endian.
+
+### Structures
+
+#### Header Structure
+
+Always at the start of the file; size 0x8.
+
+```csharp
+struct PKAHeader
+{
+    int signature;           // Value that is verified for CSIII v1.05 PC it is 0x7ff7cf0d
+    int entryCount;          // Number of Entries
+};
+```
+
+#### File Entry Structure 
+
+Following the Package Archive header; this structure is followed by a File Entry Structure. This Package Header with File Entries structure is repeated PKAHeader.entryCount times.
+
+#Package Header
+
+```csharp
+struct PkgHeader
+{
+    char fileName[32];      // Name of package (ANSI)
+    int fileCount;          // Number of files
+};
+```
+
+#### File Entry Structure 
+
+Following the Package header; this structure is repeated PkgHeader.fileCount times.
+
+```csharp
+struct FileEntry 
+{
+    char fileName[64];       // Name of file (ANSI)
+    char fileSHA256Hash[32]; // SHA256 Hash of file
+};
+```
+
+Following the final Package Header along with its  File Entry Structure are the Compression Entry Structures
+
+#### Compression Entry Structure 
+```csharp
+struct CompressionEntry 
+{
+    char fileSHA256Hash[32]; // SHA256 Hash of file this is the same as in the File Entry
+    ulong fileOffset;        // Offset to file raw data (compressed or uncompressed).
+                             // This offset is absolute; from start of package archive.
+    uint compressedSize;     // Size of file after compression.
+    uint fileSize;           // Size of file before compression.
+    int compressionType;     // 0 = Uncompressed; 
+                             // 1 = Compressed (Type A)
+                             // 2 = Compressed (Type B: Only seen in PS3 version)
+                             // 4 = Compressed with LZ4
+};
+```
+
+Compression Data then follows until the end of the archive file.


### PR DESCRIPTION
This is a Draft version of the PKA FIle Format with an emphasis on LZ4 to aid in developing software for processing the format.  It may contain errors and is not intended to be used or merged as is.
Additional compression types if I am not mistaken on their constants are:
0x01 = lzss
0x08 = lzma
0x10 = Zstd

These may alter the form of the CompressionEntry Structure, but for the pka in CSIII the only type used seems to be LZ4

If you bitwise OR the compressionType with "2" a form of hash checking or signature checking may be enabled.

The SHA256 is used to match the compression entry with the file entry.  The SHA256 sum is for the uncompressed file.


Something I noticed after making this pull request is that the number of compression entries is located in an int, which is located after the last file entry and right before the compression entries.  Also the compression entries are sorted by the sha256 hash.

| Sha256                                                           | Offset      | BlockSize | Unpacked Length | Compression Type |
|------------------------------------------------------------------|-------------|-----------|-----------------|------------------|
| 00020b4631f191068e7f8dd769650435f8ecff26dc4e7d71614712900c8ee248 | 0xe5e4a4e7  | 0x1c446   | 0x409ed         | 4                |
| 00025c8c8d9d80f71ec2c9f716c8b2788465b3c9dc4dffa8d4a580007b32552e | 0x35e2e49ef | 0x2722c0  | 0x555f65        | 4                |
|....|....|...|...|....|
| fffd99b47209bdd526bd98924fcf6034ed7581212df8698d34d0fde9d8c3ce6b | 0x203959b37 | 0x6894   | 0x38a51  | 4 |
| ffffecee944c8238ddaaf9bf0c26536afb25b46f18fa2a2722a690c9f7375366 | 0x3ec996b7  | 0x3f1    | 0xd6e    | 4 |
